### PR TITLE
Add art gallery and new game embeds

### DIFF
--- a/games-embed.html
+++ b/games-embed.html
@@ -130,25 +130,23 @@
               </div>
 
               <div class="game-widget">
-                <h3>🎰 Miku Gacha</h3>
-                <div class="gacha" id="mikuGacha">
-                  <div class="gacha-header">
-                    <div class="gacha-tokens">
-                      🎟️ Tickets: <span id="gachaTokens">0</span>
-                    </div>
-                    <div class="gacha-actions">
-                      <button id="gachaPull1" class="pixel-btn">Pull x1</button>
-                      <button id="gachaPull10" class="pixel-btn">Pull x10</button>
-                      <button id="gachaDaily" class="pixel-btn">Daily Ticket</button>
-                      <button id="gachaConvert" class="pixel-btn">100💖 → +1</button>
-                    </div>
-                  </div>
-                  <div id="gachaResults" class="gacha-results"></div>
-                  <div class="gacha-footer">
-                    <button id="gachaCollectionBtn" class="pixel-btn">Open MikuDex</button>
-                  </div>
-                  <div id="mikuDex" class="gacha-collection hidden"></div>
-                </div>
+                <h3>🕹️ Miku RPG</h3>
+                <iframe
+                  src="https://mikusquared.itch.io/rpg"
+                  style="width: 100%; height: 420px"
+                  frameborder="0"
+                  allowfullscreen
+                ></iframe>
+              </div>
+
+              <div class="game-widget">
+                <h3>🕹️ TTJ2</h3>
+                <iframe
+                  src="https://mikusquared.itch.io/ttj2"
+                  style="width: 100%; height: 420px"
+                  frameborder="0"
+                  allowfullscreen
+                ></iframe>
               </div>
 
               <div class="game-widget">

--- a/index.html
+++ b/index.html
@@ -90,6 +90,7 @@
               <li><a href="#socials" data-section="socials">🔗 Socials</a></li>
               <li><a href="#study" data-section="study">📚 日本語</a></li>
               <li><a href="#games" data-section="games">🎮 Games</a></li>
+              <li><a href="#gacha" data-section="gacha">🎰 Gacha</a></li>
               <li>
                 <a href="#shrine" data-section="shrine">⛩️ Miku Shrine</a>
               </li>
@@ -250,35 +251,23 @@
                 </div>
 
                 <div class="game-widget">
-                  <h3>🎰 Miku Gacha</h3>
-                  <div class="gacha precision" id="mikuGacha">
-                    <div class="gacha-header">
-                      <div class="gacha-tokens">
-                        🎟️ Tickets: <span id="gachaTokens">0</span>
-                      </div>
-                      <div class="gacha-actions">
-                        <button id="gachaPull1" class="pixel-btn">
-                          Pull x1
-                        </button>
-                        <button id="gachaPull10" class="pixel-btn">
-                          Pull x10
-                        </button>
-                        <button id="gachaDaily" class="pixel-btn">
-                          Daily Ticket
-                        </button>
-                        <button id="gachaConvert" class="pixel-btn">
-                          100💖 → +1
-                        </button>
-                      </div>
-                    </div>
-                    <div id="gachaResults" class="gacha-results"></div>
-                    <div class="gacha-footer">
-                      <button id="gachaCollectionBtn" class="pixel-btn">
-                        Open MikuDex
-                      </button>
-                    </div>
-                    <div id="mikuDex" class="gacha-collection hidden"></div>
-                  </div>
+                  <h3>🕹️ Miku RPG</h3>
+                  <iframe
+                    src="https://mikusquared.itch.io/rpg"
+                    style="width: 100%; height: 420px"
+                    frameborder="0"
+                    allowfullscreen
+                  ></iframe>
+                </div>
+
+                <div class="game-widget">
+                  <h3>🕹️ TTJ2</h3>
+                  <iframe
+                    src="https://mikusquared.itch.io/ttj2"
+                    style="width: 100%; height: 420px"
+                    frameborder="0"
+                    allowfullscreen
+                  ></iframe>
                 </div>
 
                 <div class="game-widget">
@@ -299,6 +288,32 @@
                       allowfullscreen
                     ></iframe>
                   </div>
+                </div>
+              </div>
+            </section>
+
+            <section id="gacha" class="content-section">
+              <h2>🎰 Miku Gacha</h2>
+              <div class="game-widget">
+                <div class="gacha precision" id="mikuGacha">
+                  <div class="gacha-header">
+                    <div class="gacha-tokens">
+                      🎟️ Tickets: <span id="gachaTokens">0</span>
+                    </div>
+                    <div class="gacha-actions">
+                      <button id="gachaPull1" class="pixel-btn">Pull x1</button>
+                      <button id="gachaPull10" class="pixel-btn">Pull x10</button>
+                      <button id="gachaDaily" class="pixel-btn">Daily Ticket</button>
+                      <button id="gachaConvert" class="pixel-btn">100💖 → +1</button>
+                    </div>
+                  </div>
+                  <div id="gachaResults" class="gacha-results"></div>
+                  <div class="gacha-footer">
+                    <button id="gachaCollectionBtn" class="pixel-btn">
+                      Open MikuDex
+                    </button>
+                  </div>
+                  <div id="mikuDex" class="gacha-collection hidden"></div>
                 </div>
               </div>
             </section>
@@ -344,6 +359,14 @@
                 <div class="image-gallery" id="mikuGallery">
                   <!-- Will be populated by JS -->
                 </div>
+              </div>
+              <div class="external-gallery">
+                <iframe
+                  src="https://www.mikucollection.com/en/art-gallery"
+                  title="Miku Collection Art Gallery"
+                  style="width: 100%; height: 600px; border: none"
+                  loading="lazy"
+                ></iframe>
               </div>
             </section>
           </main>

--- a/js/content.js
+++ b/js/content.js
@@ -150,6 +150,7 @@ window.SITE_CONTENT = {
     { id: "socials", label: "💫 Links", mikuIcon: "cheering" },
     { id: "study", label: "🎌 日本語", mikuIcon: "thumbsUp" },
     { id: "games", label: "🎮 Games", mikuIcon: "vibing" },
+    { id: "gacha", label: "🎰 Gacha", mikuIcon: "pow" },
     { id: "shrine", label: "⛩️ Shrine", mikuIcon: "stage" },
   ],
 

--- a/js/main.js
+++ b/js/main.js
@@ -4215,8 +4215,7 @@ console.log("🌸 Main.js starting execution...");
         if (h2) h2.textContent = C.games.title;
         const cards = document.querySelectorAll("#games .game-widget");
         const mem = cards[0],
-          heart = cards[1],
-          gacha = cards[2];
+          heart = cards[1];
         if (mem) {
           const h3 = mem.querySelector("h3");
           if (h3 && C.games.memoryTitle) {
@@ -4247,13 +4246,14 @@ console.log("🌸 Main.js starting execution...");
           const btn = document.getElementById("resetHearts");
           if (btn && C.games.heartsReset) btn.textContent = C.games.heartsReset;
         }
-        if (gacha) {
-          const h3 = gacha.querySelector("h3");
-          if (h3 && C.games.gachaTitle) {
+        const gachaSection = document.getElementById("gacha");
+        if (gachaSection) {
+          const gachaHeader = gachaSection.querySelector("h2");
+          if (gachaHeader && C.games.gachaTitle) {
             const gachaIcon = C.games.gachaIcon
               ? mikuIcon(C.games.gachaIcon, "🎰")
               : "🎰";
-            h3.innerHTML = /*html*/ `${gachaIcon} ${C.games.gachaTitle}`;
+            gachaHeader.innerHTML = /*html*/ `${gachaIcon} ${C.games.gachaTitle}`;
           }
           const dexBtn = document.getElementById("gachaCollectionBtn");
           if (dexBtn && C.games.gachaOpenDex)


### PR DESCRIPTION
## Summary
- Embed external Miku Collection art gallery at shrine bottom
- Add RPG and TTJ2 itch.io games
- Move gacha to its own navigation tab with icon and sound

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc543001588333a2899c430945bb32