### PR TITLE
Cap beatpad options at four

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2623,7 +2623,8 @@ console.log("🌸 Main.js starting execution...");
     async function getVocabQuestion(direction) {
       // Force a 4-grid beatpad layout (3 decoys + 1 correct)
       const preset = (window.Jukebox && Jukebox.getPreset && Jukebox.getPreset()) || { options: 4 };
-      const decoyCount = Math.max(1, (preset.options || 4) - 1);
+      const optCount = Math.min(preset.options || 4, 4);
+      const decoyCount = Math.max(1, optCount - 1);
       if (vocabCache.pages.length === 0) await primeVocabPage(rnd(50) + 1);
       if (vocabCache.enDefs.size < 12 || vocabCache.jpSurfaces.size < 12)
         await primeVocabPage(rnd(50) + 1);
@@ -2718,7 +2719,8 @@ console.log("🌸 Main.js starting execution...");
     async function getKanjiQuestion(mode) {
       // Force a 4-grid beatpad layout (3 decoys + 1 correct)
       const presetK = (window.Jukebox && Jukebox.getPreset && Jukebox.getPreset()) || { options: 4 };
-      const decoyCount = Math.max(1, (presetK.options || 4) - 1);
+      const optCountK = Math.min(presetK.options || 4, 4);
+      const decoyCount = Math.max(1, optCountK - 1);
       // Map difficulty (1-9) to school grade (1-6)
       const d = (typeof window.getJpDifficulty === 'function' ? window.getJpDifficulty() : 3) || 3;
       const gradeMap = { 1:1, 2:1, 3:2, 4:3, 5:4, 6:5, 7:6, 8:6, 9:6 };
@@ -2926,11 +2928,12 @@ console.log("🌸 Main.js starting execution...");
           qEl.innerHTML = q.promptHtml;
           // Apply per-song preset
           const PRESET = (window.Jukebox && Jukebox.getPreset && Jukebox.getPreset()) || { baseTime: 15, options: 4 };
+          const maxOpts = Math.min(PRESET.options || 4, 4);
           // If options != 4, adjust grid layout
           try {
-            const cols = PRESET.options >= 6 ? 3 : 2;
+            const cols = maxOpts >= 6 ? 3 : 2;
             cEl.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
-            cEl.style.gridTemplateRows = `repeat(${Math.ceil(PRESET.options/cols)}, 1fr)`;
+            cEl.style.gridTemplateRows = `repeat(${Math.ceil(maxOpts/cols)}, 1fr)`;
           } catch(_) {}
 
           if (timed) {
@@ -2962,7 +2965,7 @@ console.log("🌸 Main.js starting execution...");
             }, 1000);
           }
           // Trim or extend options according to preset
-          const opts = q.options.slice(0, PRESET.options || 4);
+          const opts = q.options.slice(0, maxOpts);
           q.options = opts;
           opts.forEach((opt, idx) => {
             const { btn } = createUltimateBeatpadButton(opt, idx, (text, element, style) => {
@@ -2991,7 +2994,6 @@ console.log("🌸 Main.js starting execution...");
                 fb.style.color = "#2b2b44";
                 score++;
                 scoreEl.textContent = String(score);
-                sfxOk();
                 
                 // Enhanced streak system
                 streak++;
@@ -3033,7 +3035,6 @@ console.log("🌸 Main.js starting execution...");
                 createRingEffect(element, false);
                 fb.textContent = `❌ ${correct}`;
                 fb.style.color = "#c00";
-                sfxBad();
                 streak = 0;
                 streakEl.textContent = String(streak);
                 HUD.counts.SAD++;
@@ -3042,7 +3043,7 @@ console.log("🌸 Main.js starting execution...");
                 resetCombo();
                 loseLife("vocabCard");
               }
-              
+
               if (timed) {
                 const elapsed = Date.now() - startAt;
                 if (!bestTime || elapsed < bestTime) {
@@ -3052,6 +3053,7 @@ console.log("🌸 Main.js starting execution...");
                 }
               }
               if (!HUD.gameOver) setTimeout(load, 900);
+              return isCorrect;
             });
             
             cEl.appendChild(btn);
@@ -3168,10 +3170,11 @@ console.log("🌸 Main.js starting execution...");
           const correct = q.correct;
           qEl.innerHTML = q.promptHtml;
           const PRESET2 = (window.Jukebox && Jukebox.getPreset && Jukebox.getPreset()) || { baseTime: 15, options: 4 };
+          const maxOpts2 = Math.min(PRESET2.options || 4, 4);
           try {
-            const cols2 = PRESET2.options >= 6 ? 3 : 2;
+            const cols2 = maxOpts2 >= 6 ? 3 : 2;
             cEl.style.gridTemplateColumns = `repeat(${cols2}, 1fr)`;
-            cEl.style.gridTemplateRows = `repeat(${Math.ceil(PRESET2.options/cols2)}, 1fr)`;
+            cEl.style.gridTemplateRows = `repeat(${Math.ceil(maxOpts2/cols2)}, 1fr)`;
           } catch(_) {}
           if (timed) {
             const { baseTime } = diffParams();
@@ -3201,7 +3204,7 @@ console.log("🌸 Main.js starting execution...");
               }
             }, 1000);
           }
-          const opts2 = q.options.slice(0, PRESET2.options || 4);
+          const opts2 = q.options.slice(0, maxOpts2);
           opts2.forEach((opt, idx) => {
             const { btn } = createUltimateBeatpadButton(opt, idx, (text, element, style) => {
               if (lock) return;
@@ -3226,7 +3229,6 @@ console.log("🌸 Main.js starting execution...");
                 fb.style.color = "#2b2b44";
                 score++;
                 scoreEl.textContent = String(score);
-                sfxOk();
                 
                 streak++;
                 streakEl.textContent = String(streak);
@@ -3285,7 +3287,6 @@ console.log("🌸 Main.js starting execution...");
                 createRingEffect(element, false);
                 fb.textContent = `❌ ${correct}`;
                 fb.style.color = "#c00";
-                sfxBad();
                 streak = 0;
                 streakEl.textContent = String(streak);
                 HUD.counts.SAD++;
@@ -3295,6 +3296,7 @@ console.log("🌸 Main.js starting execution...");
                 loseLife("kanjiCard");
               }
               if (!HUD.gameOver) setTimeout(load, 900);
+              return isCorrect;
             });
             
             cEl.appendChild(btn);
@@ -3352,7 +3354,8 @@ console.log("🌸 Main.js starting execution...");
             `「${q.promptHtml.replace(/<[^>]+>/g, "")}」って、どういう意味？`
           );
           const PRESET3 = (window.Jukebox && Jukebox.getPreset && Jukebox.getPreset()) || { options: 4 };
-          const use = q.options.slice(0, PRESET3.options || 4);
+          const maxOpts3 = Math.min(PRESET3.options || 4, 4);
+          const use = q.options.slice(0, maxOpts3);
           use.forEach((opt, idx) => {
             const { btn } = createUltimateBeatpadButton(opt, idx, (text, element, style) => {
               if (lock) return;
@@ -3370,7 +3373,6 @@ console.log("🌸 Main.js starting execution...");
                   say("正解だよ！");
                   addXP(10);
                 }
-                sfxOk();
                 score++;
                 scoreEl.textContent = String(score);
                 
@@ -3379,9 +3381,9 @@ console.log("🌸 Main.js starting execution...");
               } else {
                 createRingEffect(element, false);
                 say(`残念！正解は「${correct}」`);
-                sfxBad();
               }
               setTimeout(round, 900);
+              return isCorrect;
             });
             
             cEl.appendChild(btn);
@@ -3423,7 +3425,6 @@ console.log("🌸 Main.js starting execution...");
                   say("正解だよ！");
                   addXP(6);
                 }
-                sfxOk();
                 score++;
                 scoreEl.textContent = String(score);
                 
@@ -3432,9 +3433,9 @@ console.log("🌸 Main.js starting execution...");
               } else {
                 createRingEffect(element, false);
                 say(`残念！正解は「${correct}」`);
-                sfxBad();
               }
               setTimeout(round, 900);
+              return isCorrect;
             });
             
             cEl.appendChild(btn);
@@ -5847,9 +5848,16 @@ console.log("🌸 Main.js starting execution...");
         createPerfectHitEffect(btn, psBtn.color);
       }
       
-      // Call original answer handler
-      onAnswer(text, btn, { ...psBtn, isPerfect: isPerfectTiming });
-      
+      // Call original answer handler and use return value to decide SFX
+      try {
+        const res = onAnswer(text, btn, { ...psBtn, isPerfect: isPerfectTiming });
+        if (res === true) {
+          try { SFX.play('quiz.ok'); } catch(_){}
+        } else if (res === false) {
+          try { SFX.play('quiz.bad'); } catch(_){}
+        }
+      } catch(_){ onAnswer(text, btn, { ...psBtn, isPerfect: isPerfectTiming }); }
+
       // Visual feedback
       btn.style.animation = 'divaHitPulse 0.3s ease';
       setTimeout(() => btn.style.animation = '', 300);

--- a/js/modules/games/kanji.js
+++ b/js/modules/games/kanji.js
@@ -26,7 +26,8 @@
 
   async function getQuestion(mode){
     const preset = (window.Jukebox && Jukebox.getPreset && Jukebox.getPreset()) || { options:4 };
-    const decoyCount = Math.max(1,(preset.options||4)-1);
+    const optCount = Math.min(preset.options || 4, 4);
+    const decoyCount = Math.max(1, optCount - 1);
     const grade = gradeFromDiff();
     const list = await getGradeList(grade);
     for (let guard=0; guard<20; guard++){
@@ -63,7 +64,8 @@
     try{
       const q = await getQuestion(curMode); const correct = q.correct; qEl.innerHTML = q.promptHtml;
       const PRESET = (window.Jukebox && Jukebox.getPreset && Jukebox.getPreset()) || { baseTime:15, options:4 };
-      try{ const cols = PRESET.options>=6?3:2; cEl.style.gridTemplateColumns = `repeat(${cols},1fr)`; cEl.style.gridTemplateRows = `repeat(${Math.ceil(PRESET.options/cols)},1fr)`; }catch(_){ }
+      const maxOpts = Math.min(PRESET.options || 4, 4);
+      try{ const cols = maxOpts>=6?3:2; cEl.style.gridTemplateColumns = `repeat(${cols},1fr)`; cEl.style.gridTemplateRows = `repeat(${Math.ceil(maxOpts/cols)},1fr)`; }catch(_){ }
       if (isTimed()){
         const baseTime = (function(){ try{ return (window.diffParams && diffParams().baseTime) || 15; } catch(_){ return 15; } })();
         countdown = PRESET.baseTime || baseTime; if (timerEl) timerEl.textContent = String(countdown);
@@ -76,7 +78,7 @@
           }
         }, 1000);
       }
-      const use = q.options.slice(0, PRESET.options||4);
+      const use = q.options.slice(0, maxOpts);
       use.forEach((opt, idx)=>{
         const maker = window.createUltimateBeatpadButton || ((label)=>{ const btn=document.createElement('button'); btn.className='pixel-btn beatpad-btn'; btn.textContent=label; return { btn, style:{ isPerfect:false, color:'#a594f9' } }; });
         const { btn } = maker(opt, idx, (text, element, style)=> onSelect(text, element, style, correct));
@@ -96,7 +98,6 @@
       else { if (fbEl) fbEl.textContent='✅ 正解!'; try{ awardHearts && awardHearts(1); }catch(_){ } }
       if (fbEl) fbEl.style.color='#2b2b44';
       score++; if (scoreEl) scoreEl.textContent = String(score);
-      try{ SFX.play('quiz.ok'); }catch(_){ }
       streak++; if (streakEl) streakEl.textContent = String(streak); try{ if (streak>1) loveToast && loveToast(`コンボ x${streak}!`); createComboMilestoneEffect && createComboMilestoneEffect(cEl, streak); }catch(_){ }
       const mult = (function(){ try{ return diffParams().mult; }catch(_){ return 1; } })();
       const rmult = (function(){ try{ return getRhythmMult(); }catch(_){ return 1; } })();
@@ -107,11 +108,11 @@
     } else {
       try{ createRingEffect && createRingEffect(element,false); }catch(_){ }
       if (fbEl){ fbEl.textContent = `❌ ${correct}`; fbEl.style.color='#c00'; }
-      try{ SFX.play('quiz.bad'); }catch(_){ }
       streak=0; if (streakEl) streakEl.textContent=String(streak);
       try{ HUD&&HUD.counts&&(HUD.counts.SAD++); flashJudge && flashJudge('kanjiCard','SAD'); addVoltage && addVoltage(-5,'kanjiCard'); resetCombo && resetCombo(); loseLife && loseLife('kanjiCard'); }catch(_){ }
     }
     setTimeout(loadRound, 900);
+    return isCorrect;
   }
 
   function start({ mode:m, timed }){ if (m){ curMode=m; setMode(m); } if (typeof timed==='boolean') setTimed(timed); if (timerWrap) timerWrap.style.display = isTimed() ? 'inline-flex' : 'none'; loadRound(); }

--- a/js/modules/games/kotoba.js
+++ b/js/modules/games/kotoba.js
@@ -29,7 +29,8 @@
 
   async function getQuestion(){
     const preset = (window.Jukebox && Jukebox.getPreset && Jukebox.getPreset()) || { options:4 };
-    const decoyCount = Math.max(1,(preset.options||4)-1);
+    const optCount = Math.min(preset.options || 4, 4);
+    const decoyCount = Math.max(1, optCount - 1);
     // 70% from deck, 30% from jisho word search
     if (Math.random()<0.7){
       for (let guard=0; guard<20; guard++){
@@ -82,7 +83,8 @@
     try{
       const q = await getQuestion(); const correct = q.correct; if (chatEl) say(`「${q.promptHtml.replace(/<[^>]+>/g,'')}」って、どういう意味？`,'miku');
       const PRESET = (window.Jukebox && Jukebox.getPreset && Jukebox.getPreset()) || { baseTime:20, options:4 };
-      try{ const cols = PRESET.options>=6?3:2; cEl.style.gridTemplateColumns = `repeat(${cols},1fr)`; cEl.style.gridTemplateRows = `repeat(${Math.ceil(PRESET.options/cols)},1fr)`; }catch(_){ }
+      const maxOpts = Math.min(PRESET.options || 4, 4);
+      try{ const cols = maxOpts>=6?3:2; cEl.style.gridTemplateColumns = `repeat(${cols},1fr)`; cEl.style.gridTemplateRows = `repeat(${Math.ceil(maxOpts/cols)},1fr)`; }catch(_){ }
       if (isTimed()){
         const baseTime = (function(){ try{ return (window.diffParams && diffParams().baseTime) || 20; } catch(_){ return 20; } })();
         countdown = PRESET.baseTime || baseTime; if (timerEl) timerEl.textContent = String(countdown);
@@ -95,7 +97,7 @@
           }
         }, 1000);
       }
-  const use = q.options.slice(0, PRESET.options||4);
+      const use = q.options.slice(0, maxOpts);
       use.forEach((opt, idx)=>{
         const maker = window.createUltimateBeatpadButton || ((label)=>{ const btn=document.createElement('button'); btn.className='pixel-btn beatpad-btn'; btn.textContent=label; return { btn, style:{ isPerfect:false, color:'#a594f9' } }; });
         const { btn } = maker(opt, idx, (text, element, style)=> onSelect(text, element, style, correct));
@@ -116,7 +118,6 @@
       if (fbEl) fbEl.style.color='#2b2b44';
       score++; if (scoreEl) scoreEl.textContent = String(score);
       if (chatEl){ say(text,'you'); setTimeout(()=> say('やった！正解だよ！','miku'), 200); }
-      try{ SFX.play('quiz.ok'); }catch(_){ }
       streak++; if (streakEl) streakEl.textContent = String(streak); try{ if (streak>1) loveToast && loveToast(`Combo x${streak}!`); createComboMilestoneEffect && createComboMilestoneEffect(cEl, streak); }catch(_){ }
       const mult = (function(){ try{ return diffParams().mult; }catch(_){ return 1; } })();
       const rmult = (function(){ try{ return getRhythmMult(); }catch(_){ return 1; } })();
@@ -128,11 +129,11 @@
       try{ createRingEffect && createRingEffect(element,false); }catch(_){ }
       if (fbEl){ fbEl.textContent = `❌ ${correct}`; fbEl.style.color='#c00'; }
       if (chatEl){ say(text,'you'); setTimeout(()=> say(`残念… 正解は「${correct}」だよ。`,'miku'), 200); }
-      try{ SFX.play('quiz.bad'); }catch(_){ }
       streak=0; if (streakEl) streakEl.textContent=String(streak);
       try{ HUD&&HUD.counts&&(HUD.counts.SAD++); flashJudge && flashJudge('kotobaCard','SAD'); addVoltage && addVoltage(-5,'kotobaCard'); resetCombo && resetCombo(); loseLife && loseLife('kotobaCard'); }catch(_){ }
     }
     setTimeout(loadRound, 900);
+    return isCorrect;
   }
 
   function start({ timed }){ if (typeof timed==='boolean') setTimed(timed); if (timerWrap) timerWrap.style.display = isTimed() ? 'inline-flex' : 'none'; loadRound(); }


### PR DESCRIPTION
## Summary
- Ensure Japanese learning games never render more than four choices on the beatpad
- Apply four-option cap across Kotoba, Vocab and Kanji modules and central game engine
- Fix quiz SFX so incorrect answers play the "bad" sound

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc90adc4ac8333a585c2aba6cb8930