### PR TITLE
Refine heart flow and Wish layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -393,7 +393,7 @@ main {
 .hero-miku {
   width: 125px;
   height: auto;
-  animation: bounce 2s ease-in-out infinite;
+  animation: float 3s ease-in-out infinite;
 }
 
 .hero-text h2 {
@@ -1872,8 +1872,9 @@ main {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
+  gap: 12px;
   flex-wrap: wrap;
+  margin-bottom: 12px;
 }
 .Wish-actions {
   display: flex;
@@ -1896,22 +1897,22 @@ main {
 }
 .Wish-controls {
   display: flex;
-  gap: 12px;
+  gap: 16px;
   justify-content: center;
-  margin: 10px 0;
+  margin: 16px 0;
 }
 .Wish-results {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(84px, 1fr));
-  gap: 10px;
-  margin-top: 10px;
+  gap: 14px;
+  margin-top: 16px;
 }
 .Wish-card {
   position: relative;
   border: 2px solid var(--border);
   border-radius: 10px;
   background: #fff;
-  padding: 6px;
+  padding: 8px;
   box-shadow: var(--shadow);
   /* Performance optimizations */
   will-change: transform, opacity;

--- a/js/modules/hearts.js
+++ b/js/modules/hearts.js
@@ -76,12 +76,14 @@
   }
 
   function addHearts(amount){
-    heartCount += amount;
+    heartCount = Math.max(0, heartCount + amount);
     localStorage.setItem('pixelbelle-hearts', heartCount);
     updateCounters();
-  try{ const el=document.getElementById('gameHeartCount'); if (el) el.textContent=String(heartCount);}catch(_){}
-    try{ SFX.play('hearts.add'); if(amount>=5) SFX.play('extra.coin'); }catch(_){}
-    if (Array.isArray(LOVE_MILESTONES)){
+    try{ const el=document.getElementById('gameHeartCount'); if (el) el.textContent=String(heartCount);}catch(_){} 
+    if(amount>0){
+      try{ SFX.play('hearts.add'); if(amount>=5) SFX.play('extra.coin'); }catch(_){} 
+    }
+    if (amount>0 && Array.isArray(LOVE_MILESTONES)){
       const reached = LOVE_MILESTONES.filter(m=>heartCount>=m.step);
       if (reached.length){
         const top = reached.reduce((a,b)=>b.step>a.step?b:a);
@@ -89,15 +91,17 @@
           lastMilestone=top.step;
           localStorage.setItem('pixelbelle-last-milestone', lastMilestone);
           loveToast(top.msg);
-          try{ SFX.play('hearts.milestone'); }catch(_){}
+          try{ SFX.play('hearts.milestone'); }catch(_){} 
           shimejiBroadcastLove();
         }
       }
     }
-    const counterEl=document.getElementById('heartCount');
-    if(counterEl) createSparkleEffect(counterEl);
-    burstHeartsAndStars(Math.min(8,2+amount*2));
-    shimejiCelebrate(amount);
+    if(amount>0){
+      const counterEl=document.getElementById('heartCount');
+      if(counterEl) createSparkleEffect(counterEl);
+      burstHeartsAndStars(Math.min(8,2+amount*2));
+      shimejiCelebrate(amount);
+    }
   }
 
   function loadSavedData(){

--- a/js/modules/jukebox.js
+++ b/js/modules/jukebox.js
@@ -45,8 +45,11 @@
     wrap.style.cssText = 'position:fixed;right:16px;bottom:16px;width:360px;z-index:9999;background:rgba(255,255,255,.96);backdrop-filter:blur(6px);border:2px solid var(--border);border-radius:14px;box-shadow:0 10px 30px rgba(43,43,68,.25)';
     wrap.innerHTML = `
       <div style="display:flex;align-items:center;justify-content:space-between;padding:8px 10px;border-bottom:1px solid var(--border)">
-        <div style=\"font-weight:900;display:flex;align-items:center;gap:8px\">🎵 Miku Jukebox • <span id=\"jukeboxNow\">Ready</span> <span title=\"hearts\" aria-label=\"hearts\">💖</span></div>
-        <button id="jukeboxClose" class="pixel-btn" style="padding:4px 8px">✖</button>
+        <div style=\"font-weight:900;display:flex;align-items:center;gap:8px\">🎵 Miku Jukebox • <span id=\"jukeboxNow\">Ready</span></div>
+        <div style="display:flex;align-items:center;gap:6px">
+          <button id="jukeboxLove" title="send love" class="pixel-btn" style="padding:4px 8px;line-height:1">💖</button>
+          <button id="jukeboxClose" class="pixel-btn" style="padding:4px 8px">✖</button>
+        </div>
       </div>
       <div style="width:100%;aspect-ratio:16/9;overflow:hidden;background:#000;border-bottom-left-radius:12px;border-bottom-right-radius:12px">
   <iframe id="jukeboxIframe" style="width:100%;height:100%;border:0;display:block" src="about:blank" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen referrerpolicy="strict-origin-when-cross-origin"></iframe>
@@ -57,6 +60,8 @@
       wrap.style.display='none';
       try{ if (window.__resumeBgm) window.__resumeBgm(); }catch(_){ }
     };
+    const loveBtn = document.getElementById('jukeboxLove');
+    if(loveBtn) loveBtn.addEventListener('click', ()=>{ try{ addHearts(1); }catch(_){ } });
     return wrap;
   }
 


### PR DESCRIPTION
## Summary
- clamp heart totals to prevent negatives and skip celebratory effects on losses
- add love button to jukebox mini-player matching miku player's heart icon
- tweak Wish page spacing for clearer layout and revive hero Miku floating animation

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bce1c081a08333a3006de60dee89af