### PR TITLE
Fix heart sync, update Miku Symphony video, and align ring effects

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -467,10 +467,10 @@ const EN_MIKUS = [
       "https://www.mikucollection.com/en/art-gallery/hatsune-miku-symphony-2018-2019/202",
       "https://www.mikucollection.com/en/figure-details/nendoroid-1039-hatsune-miku-symphony-2018-2019-ver/266"
     ],
-    "song": "https://www.youtube.com/watch?v=dQLzXFpdWj0yss",
+    "song": "https://www.youtube.com/watch?v=dQLzXFpdWj0",
     "title": "【初音ミク】39みゅーじっく！【オリジナルMV】",
     "filename": "027 - Miku Symphony 2018 (maid).png",
-    "image": "https://img.youtube.com/vi/OuLZlZ18APQ/hqdefault.jpg"
+    "image": "https://img.youtube.com/vi/dQLzXFpdWj0/hqdefault.jpg"
   },
   {
     "id": 28,

--- a/js/modules/hearts.js
+++ b/js/modules/hearts.js
@@ -4,18 +4,26 @@ window.Hearts = (function () {
   const LOVE_TOASTS = C.love?.toasts || ["ありがとう！💖"];
   const LOVE_MILESTONES = C.love?.milestones || [];
   const SFX = window.SFX;
-  let heartCount = parseInt(
-    localStorage.getItem("pixelbelle-hearts") || "0",
-    10
-  );
+  let heartCount = 0;
   let lastMilestone = parseInt(
     localStorage.getItem("pixelbelle-last-milestone") || "0",
     10
   );
 
+  heartCount = readStoredHeartCount();
+
+  function readStoredHeartCount() {
+    const stored = parseInt(localStorage.getItem("pixelbelle-hearts") || "0", 10);
+    if (Number.isNaN(stored)) return 0;
+    return Math.max(0, stored);
+  }
+
   function updateCounters() {
+    heartCount = readStoredHeartCount();
     const el = document.getElementById("heartCount");
-    if (el) el.textContent = heartCount;
+    if (el) el.textContent = String(heartCount);
+    const hudEl = document.getElementById("gameHeartCount");
+    if (hudEl) hudEl.textContent = String(heartCount);
   }
 
   function loveToast(text) {


### PR DESCRIPTION
## Summary
- resync the heart counter from localStorage so spending hearts for tickets immediately updates the HUD
- point Miku Symphony 2018 (Maid) to a working 39 Music! YouTube link and matching preview image
- make rhythm judgment effects fall back to the lane target (with safety guards) so the right lane ring consistently appears

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68caf039837c83339d7b8beec5019c8e